### PR TITLE
[Version 0.2.0] Refactor structure, add configuration (custom logger, ignore_patterns), add inline trace

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,34 @@
+PATH
+  remote: .
+  specs:
+    rails_tracepoint_stack (0.1.4)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    diff-lcs (1.5.1)
+    rake (13.2.1)
+    rspec (3.13.0)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.0)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.1)
+
+PLATFORMS
+  x86_64-linux
+
+DEPENDENCIES
+  rails_tracepoint_stack!
+  rake
+  rspec
+
+BUNDLED WITH
+   2.4.17

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rails_tracepoint_stack (0.1.4)
+    rails_tracepoint_stack (0.2.2)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -7,16 +7,20 @@ gem install rails_tracepoint_stack
 set env 
 ```bash
 RAILS_TRACEPOINT_STACK=true
-```
+``` 
+if you wanna enable it globally on your Rails app
+
 ## Description
 
 This project aims to create a logger for method calls in Ruby <img src="https://i.pinimg.com/originals/3f/f8/de/3ff8de311854ae91dae1919f7806ff86.gif" width="40px" heigth="40px">, excluding methods from gems, internal classes, etc.
 
 By utilizing Ruby's `TracePoint` functionality, it allows monitoring and displaying the methods called during the application's execution, filtering to show only the methods defined in the application's own code.
 
-## Output
+## Usage 
 
-Sample scenario and output:
+Global use:
+
+By using the global tracing, just configuring `RAILS_TRACEPOINT_STACK` as true, you can have a sample scenario and output as:
 
 ```ruby
 module Foo
@@ -51,3 +55,42 @@ called: Bar#initialize in COMPLETE_PATH_TO_YOUR_FILE/app/services/bar.rb:METHOD_
 called: Bar#perform in COMPLETE_PATH_TO_YOUR_FILE/app/services/bar.rb:METHOD_LINE with params: {}
 called: Foo#puts_message in COMPLETE_PATH_TO_YOUR_FILE/app/services/foo:METHOD_LINE with params: {:message=>"Hello World"}
 ```
+**Enabling Locally with .enable_trace**
+
+You can also enable the tracer locally (even with `RAILS_TRACEPOINT_STACK` not defined) by passing a block of code to be traced:
+
+```ruby
+class Bar
+  include Foo
+
+  def initialize(message:)
+    @message = message
+  end
+
+  def perform
+    RailsTracepointStack.enable_trace do
+      puts_message(@message)
+    end
+  end
+end
+```
+wich will produce a similar result
+
+## Configuration
+
+You can also implement custom configuration for `RailsTracepointStack` by passing your custom configurations as follows:
+
+| Configuration     | Description                                                                                   |
+|-------------------|-----------------------------------------------------------------------------------------------|
+| `ignore_patterns` | Pass a regex pattern to filter (ignore) matched traces. Example: `/services\/foo.rb/`         |
+| `logger`          | Pass your custom logger. Example: `Rails.logger`. If not used, logs are saved in `log/rails_tracepoint_stack.log`. |
+
+Complete example:
+
+```ruby
+# config/rails_tracepoint_stack.rb
+
+RailsTracepointStack.configure do |config|
+  config.ignore_patterns << /services\/foo.rb/
+  config.logger = YourLogger
+end

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,7 @@
+
+require 'rake'
+require 'rspec/core/rake_task'
+
+RSpec::Core::RakeTask.new(:spec)
+
+task default: :spec

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,14 @@
 version
 
+<b> 0.2.0 <b>
+
+changes:
+
+- Add configuration of custom log patterns to be ignored
+- Add Rspec and Rake
+
+version
+
 <b> 0.1.4 <b>
 
 changes:

--- a/changelog.md
+++ b/changelog.md
@@ -4,8 +4,32 @@
 
 **Changes:**
 
-- Add configuration of custom log patterns to be ignored.
-- Add Rspec and Rake.
+- Refactor by separating Logger and Filter into their own classes.
+
+- Introduce `RailsTracepointStack.configure`, which allows ignoring traces with a custom pattern and customizing the logs output. Example:
+
+```ruby
+RailsTracepointStack.configure do |config|
+  config.ignore_patterns << /services\/foo.rb/
+  config.logger = YourLogger
+end
+```
+
+The default log destination is a file located on `log/rails_tracepoint_stack.log`
+
+- Add The possibility of enable the tracer locally, by calling:
+
+```ruby
+class Foo
+  def bar
+    RailsTracepointStack.enable_trace do
+      p "your code"
+    end
+  end
+end
+```
+
+- Add Rspec and Rake development dependencies, and add partial test coverage.
 
 ## 0.1.4
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,22 +1,19 @@
-version
+# Changelog
 
-<b> 0.2.0 <b>
+## 0.2.0
 
-changes:
+**Changes:**
 
-- Add configuration of custom log patterns to be ignored
-- Add Rspec and Rake
+- Add configuration of custom log patterns to be ignored.
+- Add Rspec and Rake.
 
-version
+## 0.1.4
 
-<b> 0.1.4 <b>
+**Changes:**
 
-changes:
+- Ignore logs containing `gems/bundler`.
+- Require ruby >= 3.0.
 
-ignore logs containing `gems/bundler`
+**Breaking Changes:**
 
-require ruby >= 3.0
-
-breaking changes:
-
-to enable logs catch is necessary to set `RAILS_TRACEPOINT_STACK` as `true`
+- To enable logs catch, it is necessary to set `RAILS_TRACEPOINT_STACK` as `true`.

--- a/lib/rails_tracepoint_stack.rb
+++ b/lib/rails_tracepoint_stack.rb
@@ -1,10 +1,11 @@
 require 'rails_tracepoint_stack/configuration'
+require 'rails_tracepoint_stack/tracer'
 
 $rails_tracer_rtps = nil
 
 module RailsTracepointStack
   class << self
-    attr_accessor :configuration
+    attr_accessor :configuration, :logger
   end
 
   def self.configure

--- a/lib/rails_tracepoint_stack.rb
+++ b/lib/rails_tracepoint_stack.rb
@@ -12,6 +12,16 @@ module RailsTracepointStack
     self.configuration ||= RailsTracepointStack::Configuration.new
     yield(configuration)
   end
+
+  def self.enable_trace
+    raise ArgumentError, "Block not given to #enable_trace" unless block_given?
+
+    tracer = RailsTracepointStack::Tracer.new.tracer
+    tracer.enable
+    yield
+  ensure
+    tracer.disable
+  end
 end
 
 if ENV.fetch('RAILS_TRACEPOINT_STACK', 'false') == 'true'

--- a/lib/rails_tracepoint_stack.rb
+++ b/lib/rails_tracepoint_stack.rb
@@ -1,8 +1,16 @@
+require 'rails_tracepoint_stack/configuration'
+
 $rails_tracer_rtps = nil
 
 module RailsTracepointStack
-  class <<
-    
+  class << self
+    attr_accessor :configuration
+  end
+
+  def self.configure
+    self.configuration ||= RailsTracepointStack::Configuration.new
+    yield(configuration)
+  end
 end
 
 if ENV.fetch('RAILS_TRACEPOINT_STACK', 'false') == 'true'

--- a/lib/rails_tracepoint_stack.rb
+++ b/lib/rails_tracepoint_stack.rb
@@ -1,43 +1,12 @@
 $rails_tracer_rtps = nil
 
-class RailsTracepointStack
-  def initialize
-    @gem_paths = Bundler.load.specs.map(&:full_gem_path)
-    @ruby_lib_path = RbConfig::CONFIG['rubylibdir']
-  end
-
-  def tracer
-    @trace ||=  TracePoint.new(:call) do |tp|
-      next if start_with_to_ignore_prefixes?(tp) || from_gempath_or_lib_path?(tp)
-
-      params = fetch_params(tp)
-      
-      puts "called: #{tp.defined_class}##{tp.method_id} in #{tp.path}:#{tp.lineno} with params: #{params}"
-    end
-  end
-
-  private
-  attr_reader :gem_paths, :ruby_lib_path
-
-  def fetch_params(tp)
-    tp.binding.local_variables.map { |var|
-      [var, tp.binding.local_variable_get(var)]
-    }.to_h
-  end
-
-  def start_with_to_ignore_prefixes?(tp)
-    tp.path.start_with?('<internal:') || tp.path == '(eval)'
-  end
-
-  def from_gempath_or_lib_path?(tp)
-    gem_paths.any? { |path| tp.path.start_with?(path) } || 
-    tp.path.start_with?(ruby_lib_path) || 
-    tp.path.include?("gems/bundler") 
-  end
+module RailsTracepointStack
+  class <<
+    
 end
 
 if ENV.fetch('RAILS_TRACEPOINT_STACK', 'false') == 'true'
-  $rails_tracer_rtps = RailsTracepointStack.new.tracer
+  $rails_tracer_rtps = RailsTracepointStack::Tracer.new.tracer
   $rails_tracer_rtps.enable
 
   at_exit do

--- a/lib/rails_tracepoint_stack/config.rb
+++ b/lib/rails_tracepoint_stack/config.rb
@@ -1,0 +1,9 @@
+module RailsTracepointStack
+  class Config
+    attr_accessor :ignore_patterns
+
+    def initialize
+      @ignore_patterns = []
+    end
+  end
+end

--- a/lib/rails_tracepoint_stack/configuration.rb
+++ b/lib/rails_tracepoint_stack/configuration.rb
@@ -1,9 +1,10 @@
 module RailsTracepointStack
   class Configuration
-    attr_accessor :ignore_patterns
+    attr_accessor :ignore_patterns, :logger
 
     def initialize
       @ignore_patterns = []
+      @logger = nil
     end
   end
 end

--- a/lib/rails_tracepoint_stack/configuration.rb
+++ b/lib/rails_tracepoint_stack/configuration.rb
@@ -1,5 +1,5 @@
 module RailsTracepointStack
-  class Config
+  class Configuration
     attr_accessor :ignore_patterns
 
     def initialize

--- a/lib/rails_tracepoint_stack/logger.rb
+++ b/lib/rails_tracepoint_stack/logger.rb
@@ -1,7 +1,7 @@
 module RailsTracepointStack
   class Logger
     def self.log(msg)
-      if RailsTracepointStack.configuration.logger.nil?
+      unless RailsTracepointStack.configuration&.logger
         File.open('log/rails_tracepoint_stack.log', 'a') do |f|
           f.puts msg
         end

--- a/lib/rails_tracepoint_stack/logger.rb
+++ b/lib/rails_tracepoint_stack/logger.rb
@@ -1,0 +1,14 @@
+module RailsTracepointStack
+  class Logger
+    def self.log(msg)
+      if RailsTracepointStack.configuration.logger.nil?
+        File.open('log/rails_tracepoint_stack.log', 'a') do |f|
+          f.puts msg
+        end
+      else
+        RailsTracepointStack.configuration.logger.info(msg)
+      end
+    end
+  end
+end
+

--- a/lib/rails_tracepoint_stack/trace_filter.rb
+++ b/lib/rails_tracepoint_stack/trace_filter.rb
@@ -1,0 +1,31 @@
+module RailsTracepointStack
+  class TraceFilter
+    def self.ignore_trace?(trace:)
+      start_with_to_ignore_prefixes?(trace) || from_gempath_or_lib_path?(trace) || is_a_to_ignore_pattern?(trace)
+    end
+
+    private
+
+    def self.gem_paths
+      @gem_paths ||= Bundler.load.specs.map(&:full_gem_path)
+    end
+
+    def self.ruby_lib_path
+      @ruby_lib_path ||= RbConfig::CONFIG['rubylibdir']
+    end
+    
+    def self.start_with_to_ignore_prefixes?(trace)
+      trace.path.start_with?('<internal:') || trace.path == '(eval)'
+    end
+
+    def self.from_gempath_or_lib_path?(trace)
+      gem_paths.any? { |path| trace.path.start_with?(path) } || 
+        trace.path.start_with?(ruby_lib_path) || 
+          trace.path.include?("gems/bundler")
+    end
+
+    def self.is_a_to_ignore_pattern?(trace)
+      RailsTracepointStack.configuration.ignore_patterns.any? { |pattern| trace.path.match?(pattern) }
+    end
+  end
+end

--- a/lib/rails_tracepoint_stack/trace_filter.rb
+++ b/lib/rails_tracepoint_stack/trace_filter.rb
@@ -25,7 +25,7 @@ module RailsTracepointStack
     end
 
     def self.is_a_to_ignore_pattern?(trace)
-      RailsTracepointStack.configuration.ignore_patterns.any? { |pattern| trace.path.match?(pattern) }
+      RailsTracepointStack.configuration&.ignore_patterns&.any? { |pattern| trace.path.match?(pattern) }
     end
   end
 end

--- a/lib/rails_tracepoint_stack/tracer.rb
+++ b/lib/rails_tracepoint_stack/tracer.rb
@@ -1,0 +1,39 @@
+
+module RailsTracepointStack
+  class Tracer
+    def initialize
+      @gem_paths = Bundler.load.specs.map(&:full_gem_path)
+      @ruby_lib_path = RbConfig::CONFIG['rubylibdir']
+    end
+
+    def tracer
+      @trace ||=  TracePoint.new(:call) do |tp|
+        next if start_with_to_ignore_prefixes?(tp) || from_gempath_or_lib_path?(tp)
+
+        params = fetch_params(tp)
+        
+        puts "called: #{tp.defined_class}##{tp.method_id} in #{tp.path}:#{tp.lineno} with params: #{params}"
+      end
+    end
+
+    private
+    attr_reader :gem_paths, :ruby_lib_path
+
+    def fetch_params(tp)
+      tp.binding.local_variables.map { |var|
+        [var, tp.binding.local_variable_get(var)]
+      }.to_h
+    end
+
+    def start_with_to_ignore_prefixes?(tp)
+      tp.path.start_with?('<internal:') || tp.path == '(eval)'
+    end
+
+    def from_gempath_or_lib_path?(tp)
+      gem_paths.any? { |path| tp.path.start_with?(path) } || 
+      tp.path.start_with?(ruby_lib_path) || 
+      tp.path.include?("gems/bundler") || 
+      RailsTracepointStack.configuration.ignore_patterns.any? { |pattern| tp.path.include?(pattern) }
+    end
+  end
+end

--- a/lib/rails_tracepoint_stack/tracer.rb
+++ b/lib/rails_tracepoint_stack/tracer.rb
@@ -1,18 +1,15 @@
+require 'rails_tracepoint_stack/logger'
+require 'rails_tracepoint_stack/trace_filter'
 
 module RailsTracepointStack
   class Tracer
-    def initialize
-      @gem_paths = Bundler.load.specs.map(&:full_gem_path)
-      @ruby_lib_path = RbConfig::CONFIG['rubylibdir']
-    end
-
     def tracer
-      @trace ||=  TracePoint.new(:call) do |tp|
-        next if start_with_to_ignore_prefixes?(tp) || from_gempath_or_lib_path?(tp)
+      @trace ||= TracePoint.new(:call) do |tp|
+        next if RailsTracepointStack::TraceFilter.ignore_trace?(trace: tp)
 
         params = fetch_params(tp)
         
-        puts "called: #{tp.defined_class}##{tp.method_id} in #{tp.path}:#{tp.lineno} with params: #{params}"
+        RailsTracepointStack::Logger.log "called: #{tp.defined_class}##{tp.method_id} in #{tp.path}:#{tp.lineno} with params: #{params}"
       end
     end
 
@@ -23,17 +20,6 @@ module RailsTracepointStack
       tp.binding.local_variables.map { |var|
         [var, tp.binding.local_variable_get(var)]
       }.to_h
-    end
-
-    def start_with_to_ignore_prefixes?(tp)
-      tp.path.start_with?('<internal:') || tp.path == '(eval)'
-    end
-
-    def from_gempath_or_lib_path?(tp)
-      gem_paths.any? { |path| tp.path.start_with?(path) } || 
-      tp.path.start_with?(ruby_lib_path) || 
-      tp.path.include?("gems/bundler") || 
-      RailsTracepointStack.configuration.ignore_patterns.any? { |pattern| tp.path.include?(pattern) }
     end
   end
 end

--- a/rails_tracepoint_stack.gemspec
+++ b/rails_tracepoint_stack.gemspec
@@ -10,4 +10,7 @@ Gem::Specification.new do |s|
   s.license     = "MIT"
   s.metadata["documentation_uri"] = "https://github.com/carlosdanielpohlod/rails_tracepoint_stack/"
   s.required_ruby_version = '>= 3.0'
+
+  s.add_development_dependency 'rspec'
+  s.add_development_dependency 'rake'
 end

--- a/rails_tracepoint_stack.gemspec
+++ b/rails_tracepoint_stack.gemspec
@@ -1,11 +1,16 @@
 Gem::Specification.new do |s|
   s.name        = "rails_tracepoint_stack"
-  s.version     = "0.1.4"
+  s.version     = "0.2.0"
   s.summary     = "Get a complete stack trace for your code on a Rails application."
   s.description = "A formatted output of all methods called in your rails application of code created by the developer, with the complete path to the class/module, including passed params."
   s.authors     = ["Carlos Daniel Pohlod"]
   s.email       = "carlospohlod@gmail.com"
-  s.files       = ["lib/rails_tracepoint_stack.rb"]
+  s.files       = [
+    "lib/rails_tracepoint_stack.rb", 
+    "lib/rails_tracepoint_stack/logger.rb", 
+    "lib/rails_tracepoint_stack/tracer.rb", 
+    "lib/rails_tracepoint_stack/trace_filter.rb"
+  ]
   s.homepage    = "https://github.com/carlosdanielpohlod/rails_tracepoint_stack/"
   s.license     = "MIT"
   s.metadata["documentation_uri"] = "https://github.com/carlosdanielpohlod/rails_tracepoint_stack/"

--- a/rails_tracepoint_stack.gemspec
+++ b/rails_tracepoint_stack.gemspec
@@ -9,13 +9,14 @@ Gem::Specification.new do |s|
     "lib/rails_tracepoint_stack.rb", 
     "lib/rails_tracepoint_stack/logger.rb", 
     "lib/rails_tracepoint_stack/tracer.rb", 
-    "lib/rails_tracepoint_stack/trace_filter.rb"
+    "lib/rails_tracepoint_stack/trace_filter.rb",
+    "lib/rails_tracepoint_stack/configuration.rb"
   ]
   s.homepage    = "https://github.com/carlosdanielpohlod/rails_tracepoint_stack/"
   s.license     = "MIT"
   s.metadata["documentation_uri"] = "https://github.com/carlosdanielpohlod/rails_tracepoint_stack/"
   s.required_ruby_version = '>= 3.0'
 
-  s.add_development_dependency 'rspec'
-  s.add_development_dependency 'rake'
+  s.add_development_dependency 'rspec', '>= 6.0'
+  s.add_development_dependency 'rake', '>= 12.0'
 end

--- a/rails_tracepoint_stack.gemspec
+++ b/rails_tracepoint_stack.gemspec
@@ -15,8 +15,9 @@ Gem::Specification.new do |s|
   s.homepage    = "https://github.com/carlosdanielpohlod/rails_tracepoint_stack/"
   s.license     = "MIT"
   s.metadata["documentation_uri"] = "https://github.com/carlosdanielpohlod/rails_tracepoint_stack/"
-  s.required_ruby_version = '>= 3.0'
+  s.metadata["changelog_uri"] = "https://github.com/carlosdanielpohlod/rails_tracepoint_stack/blob/main/changelog.md"
 
-  s.add_development_dependency 'rspec', '>= 6.0'
-  s.add_development_dependency 'rake', '>= 12.0'
+  s.required_ruby_version = '>= 3.0'
+  s.add_development_dependency 'rspec', '~> 6.0', '>= 6.0.0'
+  s.add_development_dependency 'rake', '~> 12.0', '>= 12.0.0'
 end

--- a/spec/rails_tracepoint_stack/logger_spec.rb
+++ b/spec/rails_tracepoint_stack/logger_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_tracepoint_stack/logger'
+require 'rails_tracepoint_stack'
+require 'fileutils'
+
+RSpec.describe RailsTracepointStack::Logger do
+  let(:log_message) { "This is a test log message." }
+  let(:log_file_path) { 'log/rails_tracepoint_stack.log' }
+  context "when provide a custom logger" do
+    let(:custom_logger) { double('Logger', info: true) }
+    before do
+      RailsTracepointStack.configure do |config|
+        config.logger = custom_logger
+      end
+    end
+    
+    it 'uses the custom logger to log the message' do
+      described_class.log(log_message)
+
+      expect(custom_logger)
+        .to have_received(:info)
+        .with(log_message)
+    end
+  end
+
+  context "when no custom logger is provided" do
+    before do
+      RailsTracepointStack.configure do |config|
+        config.logger = nil
+      end
+
+      allow(File)
+        .to receive(:open)
+        .with('log/rails_tracepoint_stack.log', 'a')
+    end
+
+    it 'logs the message to the default log file' do
+      described_class.log(log_message)
+
+      expect(File).to have_received(:open)
+    end
+  end
+end

--- a/spec/rails_tracepoint_stack/trace_filter_spec.rb
+++ b/spec/rails_tracepoint_stack/trace_filter_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_tracepoint_stack'
+require 'rails_tracepoint_stack/trace_filter'
+require 'rspec'
+require 'bundler'
+require 'ostruct'
+
+RSpec.describe RailsTracepointStack::TraceFilter do
+  before(:all) do
+    RailsTracepointStack.configure do |config|
+      config.ignore_patterns << /ignore_pattern/
+    end
+  end
+
+  context 'when trace is from internal sources' do
+    let(:internal_trace) { OpenStruct.new(path: '<internal:kernel>') }
+
+    it 'ignores the trace' do
+      expect(described_class.ignore_trace?(trace: internal_trace)).to be true
+    end
+  end
+
+  context 'when trace matches an ignore pattern' do
+    let(:pattern_trace) { OpenStruct.new(path: 'some_path/ignore_pattern/some_file.rb') }
+
+    it 'ignores the trace' do
+      expect(described_class.ignore_trace?(trace: pattern_trace)).to be true
+    end
+  end
+
+  context 'when trace does not meet any ignore criteria' do
+    let(:normal_trace) { OpenStruct.new(path: 'some_path/some_file.rb') }
+
+    it 'does not ignore the trace' do
+      expect(described_class.ignore_trace?(trace: normal_trace)).to be false
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,7 @@
+$LOAD_PATH.unshift File.expand_path("../lib", __dir__)
+
+RSpec.configure do |config|
+  config.order = :random
+  config.filter_run_when_matching :focus
+  config.raise_errors_for_deprecations!
+end

--- a/spec/tracer_spec.rb
+++ b/spec/tracer_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+require 'rails_tracepoint_stack'
+require 'rails_tracepoint_stack/tracer'
+require 'ostruct'
+
+class Foo
+  def dummy_method
+    return
+  end
+end
+
+class IgnoredClass
+  def ignored_method
+    return
+  end
+end
+
+RSpec.describe RailsTracepointStack::Tracer do
+  before do
+    RailsTracepointStack.configuration do |config|
+      #TO DO: change it or both classes will be ignored
+      config.ignore_patterns = ['spec/tracer_spec.rb']
+    end
+    @tracer = RailsTracepointStack::Tracer.new
+  end
+
+  it 'show methods outside the ignore patterns' do
+    expect {
+      @tracer.tracer.enable
+        Foo.new.dummy_method
+      @tracer.tracer.disable
+    }.to output(/called: Foo#dummy_method/).to_stdout
+  end
+
+  it 'not show ignored classess' do
+    expect {
+      @tracer.tracer.enable
+
+      IgnoredClass.new.ignored_method
+      @tracer.tracer.disable
+    }.not_to output(/called: IgnoredClass#ignored_method/).to_stdout
+  end
+end


### PR DESCRIPTION
This PR introduces several enhancements and features:

- Separates Logger and Filter into their own classes for better organization.
- Adds a configuration option (`RailsTracepointStack.configure`) to ignore specific traces and customize log output.
```ruby
# config/rails_tracepoint_stack.rb

RailsTracepointStack.configure do |config|
  config.ignore_patterns << /services\/foo.rb/
  config.logger = YourLogger
end
```
- Sets the default log destination to `log/rails_tracepoint_stack.log`.
- Enables local tracing within specific code blocks using `RailsTracepointStack.enable_trace`.

```ruby
class Foo
  def bar
    RailsTracepointStack.enable_trace do
      p "your code"
    end
  end
end
```

- Adds RSpec and Rake as development dependencies and includes partial test coverage.