### PR TITLE
Fix flaky `spec/rails_tracepoint_stack_spec.rb`

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,4 +8,10 @@ RSpec.configure do |config|
   config.order = :random
   config.filter_run_when_matching :focus
   config.raise_errors_for_deprecations!
+
+  config.around do |example|
+    original_config = RailsTracepointStack.configuration.dup
+    example.run
+    RailsTracepointStack.configuration = original_config  
+  end
 end


### PR DESCRIPTION
Fixes #15.

Sets an `around` hook to store and then restore the original `RailsTracepointStack.configuration` values. This ensure each example will run with the default configuration.