### PR TITLE
fix: fix CustomTraceSelectorFilter to return true when a trace matches with the provided filters

### DIFF
--- a/lib/rails_tracepoint_stack/filter/custom_trace_selector_filter.rb
+++ b/lib/rails_tracepoint_stack/filter/custom_trace_selector_filter.rb
@@ -4,7 +4,7 @@ module RailsTracepointStack
       def is_a_trace_required_to_watch_by_the_custom_configs?(trace:)
         return false unless RailsTracepointStack.configuration.file_path_to_filter_patterns.any?
 
-        !filter_match_a_custom_pattern_to_be_not_ignored?(trace)
+        filter_match_a_custom_pattern_to_be_not_ignored?(trace)
       end
 
       private

--- a/spec/rails_tracepoint_stack/filter/custom_trace_selector_filter_spec.rb
+++ b/spec/rails_tracepoint_stack/filter/custom_trace_selector_filter_spec.rb
@@ -11,10 +11,12 @@ RSpec.describe RailsTracepointStack::Filter::CustomTraceSelectorFilter do
       let(:trace) { instance_double(RailsTracepointStack::Trace, file_path: file_path) }
 
       before do
-        allow(RailsTracepointStack.configuration).to receive(:file_path_to_filter_patterns).and_return([/app\/controllers/])
+        allow(RailsTracepointStack.configuration)
+          .to receive(:file_path_to_filter_patterns)
+          .and_return([/app\/controllers/])
       end
 
-      it { is_expected.to be_falsey }
+      it { is_expected.to be_truthy }
     end
    
     context "when the trace's file path does not match a custom pattern" do
@@ -22,10 +24,12 @@ RSpec.describe RailsTracepointStack::Filter::CustomTraceSelectorFilter do
       let(:trace) { instance_double(RailsTracepointStack::Trace, file_path: file_path) }
 
       before do
-        allow(RailsTracepointStack.configuration).to receive(:file_path_to_filter_patterns).and_return([/app\/controllers/])
+        allow(RailsTracepointStack.configuration)
+          .to receive(:file_path_to_filter_patterns)
+          .and_return([/app\/controllers/])
       end
 
-      it { is_expected.to be_truthy }
+      it { is_expected.to be_falsey }
     end
   end
 end 

--- a/spec/shared/tracer_examples.rb
+++ b/spec/shared/tracer_examples.rb
@@ -1,15 +1,5 @@
 RSpec.shared_examples "tracer success examples asserts" do
   context "when log format is text" do
-    before do
-      # RailsTracepointStack.configure do |config|
-      #   config.log_format = :text
-      # end
-
-      allow(RailsTracepointStack.configuration)
-        .to receive(:log_format)
-        .and_return(:text)
-    end
-
     it 'calls logger with correct log' do
       tracer.tracer.enable do
         Foo.new.dummy_method
@@ -23,10 +13,6 @@ RSpec.shared_examples "tracer success examples asserts" do
 
   context "when log format is json" do
     before do
-      # RailsTracepointStack.configure do |config|
-      #   config.log_format = :json
-      # end
-
       allow(RailsTracepointStack.configuration)
         .to receive(:log_format)
         .and_return(:json)

--- a/spec/shared/tracer_examples.rb
+++ b/spec/shared/tracer_examples.rb
@@ -1,0 +1,45 @@
+RSpec.shared_examples "tracer success examples asserts" do
+  context "when log format is text" do
+    before do
+      # RailsTracepointStack.configure do |config|
+      #   config.log_format = :text
+      # end
+
+      allow(RailsTracepointStack.configuration)
+        .to receive(:log_format)
+        .and_return(:text)
+    end
+
+    it 'calls logger with correct log' do
+      tracer.tracer.enable do
+        Foo.new.dummy_method
+      end
+
+      expect(RailsTracepointStack::Logger)
+        .to have_received(:log)
+        .with("called: Foo#dummy_method in /app/rails_tracepoint_stack/spec/tracer_spec.rb:6 with params: {}")
+    end
+  end
+
+  context "when log format is json" do
+    before do
+      # RailsTracepointStack.configure do |config|
+      #   config.log_format = :json
+      # end
+
+      allow(RailsTracepointStack.configuration)
+        .to receive(:log_format)
+        .and_return(:json)
+    end
+    # TODO: Extract this test to a proper place
+    it 'calls logger with correct log with json log format' do
+      tracer.tracer.enable do
+        Foo.new.dummy_method
+      end
+
+      expect(RailsTracepointStack::Logger)
+        .to have_received(:log)
+        .with("{\"class\":\"Foo\",\"method_name\":\"dummy_method\",\"path\":\"/app/rails_tracepoint_stack/spec/tracer_spec.rb\",\"line\":6,\"params\":{}}")
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 Dir[File.join(File.dirname(__FILE__), '../lib/**/*.rb')].sort.each { |file| require file }
+Dir[File.join(File.dirname(__FILE__), './shared/**/*.rb')].each { |f| require f }
 
 def initialize_gem_configuration!
   RailsTracepointStack.configuration = RailsTracepointStack::Configuration.new


### PR DESCRIPTION
- fix CustomTraceSelectorFilter to return true when a trace matches with the provided filters

- add a shared context to reuse the success case for tracer tests