### PR TITLE
#37 Fix stack level too deep in JSON trace logging

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rails_tracepoint_stack (0.3.4)
+    rails_tracepoint_stack (0.3.5)
 
 GEM
   remote: https://rubygems.org/

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.3.5
+
+**BugFix**
+
+- Sanitize traced params before formatting so JSON logging does not overflow on recursive or problematic objects [Issue #37](https://github.com/carlosdanielpohlod/rails_tracepoint_stack/issues/37)
+- Stabilize text log param rendering across Ruby versions
+
 ## 0.3.4
 
 **Changes**

--- a/lib/rails_tracepoint_stack/log_formatter.rb
+++ b/lib/rails_tracepoint_stack/log_formatter.rb
@@ -1,3 +1,5 @@
+require "json"
+
 module RailsTracepointStack
   module LogFormatter
     def self.message(trace)
@@ -14,13 +16,88 @@ module RailsTracepointStack
     end
 
     def self.json(trace)
-      {
-        class: trace.class_name,
-        method_name: trace.method_name,
-        path: trace.file_path,
+      JSON.generate(
+        class: stringify(trace.class_name),
+        method_name: stringify(trace.method_name),
+        path: stringify(trace.file_path),
         line: trace.line_number,
-        params: trace.params
-      }.to_json
+        params: safe_value(trace.params)
+      )
+    end
+
+    def self.stringify(value)
+      return nil if value.nil?
+
+      value.to_s
+    rescue SystemStackError, StandardError => error
+      inspect_fallback(value, error)
+    end
+
+    def self.safe_value(value, ancestry = {})
+      case value
+      when nil, true, false, Numeric, String
+        value
+      when Symbol
+        value.to_s
+      when Array
+        safe_array(value, ancestry)
+      when Hash
+        safe_hash(value, ancestry)
+      else
+        safe_object_string(value)
+      end
+    rescue SystemStackError, StandardError => error
+      inspect_fallback(value, error)
+    end
+
+    def self.safe_array(value, ancestry)
+      object_id = value.__id__
+      return recursive_placeholder(value) if ancestry.key?(object_id)
+
+      ancestry[object_id] = true
+      value.map { |item| safe_value(item, ancestry) }
+    ensure
+      ancestry.delete(object_id)
+    end
+
+    def self.safe_hash(value, ancestry)
+      object_id = value.__id__
+      return recursive_placeholder(value) if ancestry.key?(object_id)
+
+      ancestry[object_id] = true
+      value.each_with_object({}) do |(key, item), result|
+        result[safe_hash_key(key)] = safe_value(item, ancestry)
+      end
+    ensure
+      ancestry.delete(object_id)
+    end
+
+    def self.safe_hash_key(key)
+      case key
+      when String
+        key
+      when Symbol, Numeric
+        key.to_s
+      when true, false, nil
+        key.inspect
+      else
+        safe_object_string(key)
+      end
+    end
+
+    def self.safe_object_string(value)
+      value.inspect
+    rescue SystemStackError, StandardError => error
+      inspect_fallback(value, error)
+    end
+
+    def self.inspect_fallback(value, error)
+      class_name = value.nil? ? "NilClass" : value.class.to_s
+      "#<#{class_name} unserializable: #{error.class}: #{error.message}>"
+    end
+
+    def self.recursive_placeholder(value)
+      "[recursive #{value.class}]"
     end
   end
 end

--- a/lib/rails_tracepoint_stack/log_formatter.rb
+++ b/lib/rails_tracepoint_stack/log_formatter.rb
@@ -12,7 +12,7 @@ module RailsTracepointStack
     end
 
     def self.text(trace)
-      "called: #{trace.class_name}##{trace.method_name} in #{trace.file_path}:#{trace.line_number} with params: #{trace.params}"
+      "called: #{trace.class_name}##{trace.method_name} in #{trace.file_path}:#{trace.line_number} with params: #{text_value(trace.params)}"
     end
 
     def self.json(trace)
@@ -98,6 +98,62 @@ module RailsTracepointStack
 
     def self.recursive_placeholder(value)
       "[recursive #{value.class}]"
+    end
+
+    def self.text_value(value, ancestry = {})
+      case value
+      when nil
+        "nil"
+      when true, false, Numeric
+        value.to_s
+      when String
+        value.inspect
+      when Symbol
+        ":#{value}"
+      when Array
+        text_array(value, ancestry)
+      when Hash
+        text_hash(value, ancestry)
+      else
+        safe_object_string(value)
+      end
+    rescue SystemStackError, StandardError => error
+      inspect_fallback(value, error)
+    end
+
+    def self.text_array(value, ancestry)
+      object_id = value.__id__
+      return recursive_placeholder(value) if ancestry.key?(object_id)
+
+      ancestry[object_id] = true
+      "[#{value.map { |item| text_value(item, ancestry) }.join(", ")}]"
+    ensure
+      ancestry.delete(object_id)
+    end
+
+    def self.text_hash(value, ancestry)
+      object_id = value.__id__
+      return recursive_placeholder(value) if ancestry.key?(object_id)
+
+      ancestry[object_id] = true
+      pairs = value.map do |key, item|
+        "#{text_hash_key(key)}=>#{text_value(item, ancestry)}"
+      end
+
+      "{#{pairs.join(", ")}}"
+    ensure
+      ancestry.delete(object_id)
+    end
+
+    def self.text_hash_key(key)
+      case key
+      when Symbol
+        ":#{key}"
+      when String
+        key.inspect
+      else
+        text_value(key)
+      end
     end
   end
 end

--- a/lib/rails_tracepoint_stack/log_formatter.rb
+++ b/lib/rails_tracepoint_stack/log_formatter.rb
@@ -44,7 +44,7 @@ module RailsTracepointStack
       when Hash
         safe_hash(value, ancestry)
       else
-        safe_object_string(value)
+        safe_json_object(value)
       end
     rescue SystemStackError, StandardError => error
       inspect_fallback(value, error)
@@ -66,13 +66,13 @@ module RailsTracepointStack
 
       ancestry[object_id] = true
       value.each_with_object({}) do |(key, item), result|
-        result[safe_hash_key(key)] = safe_value(item, ancestry)
+        result[safe_hash_key(key, ancestry)] = safe_value(item, ancestry)
       end
     ensure
       ancestry.delete(object_id)
     end
 
-    def self.safe_hash_key(key)
+    def self.safe_hash_key(key, ancestry = {})
       case key
       when String
         key
@@ -81,8 +81,43 @@ module RailsTracepointStack
       when true, false, nil
         key.inspect
       else
-        safe_object_string(key)
+        stringify_hash_key(key, ancestry)
       end
+    end
+
+    def self.safe_json_object(value)
+      json_value = JSON.parse(JSON.generate(value))
+
+      return json_value unless default_string_representation?(value, json_value)
+
+      safe_object_string(value)
+    rescue SystemStackError, StandardError
+      safe_object_string(value)
+    end
+
+    def self.default_string_representation?(value, json_value)
+      json_value.is_a?(String) &&
+        value.method(:to_s).owner == Kernel &&
+        json_value == value.to_s
+    rescue SystemStackError, StandardError
+      false
+    end
+
+    def self.stringify_hash_key(key, ancestry)
+      normalized_key = safe_value(key, ancestry)
+
+      case normalized_key
+      when String
+        normalized_key
+      when nil
+        "null"
+      when true, false, Numeric
+        normalized_key.to_s
+      else
+        JSON.generate(normalized_key)
+      end
+    rescue SystemStackError, StandardError
+      safe_object_string(key)
     end
 
     def self.safe_object_string(value)
@@ -137,7 +172,7 @@ module RailsTracepointStack
 
       ancestry[object_id] = true
       pairs = value.map do |key, item|
-        "#{text_hash_key(key)}=>#{text_value(item, ancestry)}"
+        "#{text_hash_key(key, ancestry)}=>#{text_value(item, ancestry)}"
       end
 
       "{#{pairs.join(", ")}}"
@@ -145,14 +180,14 @@ module RailsTracepointStack
       ancestry.delete(object_id)
     end
 
-    def self.text_hash_key(key)
+    def self.text_hash_key(key, ancestry = {})
       case key
       when Symbol
         ":#{key}"
       when String
         key.inspect
       else
-        text_value(key)
+        text_value(key, ancestry)
       end
     end
   end

--- a/lib/rails_tracepoint_stack/version.rb
+++ b/lib/rails_tracepoint_stack/version.rb
@@ -1,3 +1,3 @@
 module RailsTracepointStack
-  VERSION = "0.3.4"
+  VERSION = "0.3.5"
 end

--- a/spec/rails_tracepoint_stack/log_formatter_spec.rb
+++ b/spec/rails_tracepoint_stack/log_formatter_spec.rb
@@ -1,5 +1,6 @@
 require "spec_helper"
 require "json"
+require "uri"
 
 RSpec.describe RailsTracepointStack::LogFormatter do
   let(:trace_double) do
@@ -83,6 +84,18 @@ RSpec.describe RailsTracepointStack::LogFormatter do
       )
     end
 
+    it "preserves useful JSON output for serializable objects" do
+      allow(trace_double)
+        .to receive(:params)
+        .and_return({uri: URI("http://example.com")})
+
+      parsed_json = JSON.parse(described_class.json(trace_double))
+
+      expect(parsed_json.fetch("params")).to eq(
+        "uri" => "http://example.com"
+      )
+    end
+
     it "falls back when a param inspect raises SystemStackError" do
       exploding_object = Class.new do
         def inspect
@@ -98,6 +111,38 @@ RSpec.describe RailsTracepointStack::LogFormatter do
 
       expect(parsed_json.fetch("params")).to eq(
         "payload" => "#<#{exploding_object.class} unserializable: SystemStackError: stack level too deep>"
+      )
+    end
+
+    it "serializes recursive hash keys without blowing the stack" do
+      recursive_payload = {}
+      recursive_key = recursive_payload
+      recursive_payload[recursive_key] = 1
+
+      allow(trace_double)
+        .to receive(:params)
+        .and_return(recursive_payload)
+
+      parsed_json = JSON.parse(described_class.json(trace_double))
+
+      expect(parsed_json.fetch("params")).to eq(
+        "[recursive Hash]" => 1
+      )
+    end
+  end
+
+  describe ".text" do
+    it "renders recursive hash keys without blowing the stack" do
+      recursive_payload = {}
+      recursive_key = recursive_payload
+      recursive_payload[recursive_key] = 1
+
+      allow(trace_double)
+        .to receive(:params)
+        .and_return(recursive_payload)
+
+      expect(described_class.text(trace_double)).to eq(
+        "called: MyClass#my_method in /path/to/file.rb:42 with params: {[recursive Hash]=>1}"
       )
     end
   end

--- a/spec/rails_tracepoint_stack/log_formatter_spec.rb
+++ b/spec/rails_tracepoint_stack/log_formatter_spec.rb
@@ -65,5 +65,40 @@ RSpec.describe RailsTracepointStack::LogFormatter do
 
       expect(described_class.json(trace_double)).to eq(expected_json)
     end
+
+    it "serializes recursive params without blowing the stack" do
+      recursive_payload = {}
+      recursive_payload[:self] = recursive_payload
+
+      allow(trace_double)
+        .to receive(:params)
+        .and_return({payload: recursive_payload})
+
+      parsed_json = JSON.parse(described_class.json(trace_double))
+
+      expect(parsed_json.fetch("params")).to eq(
+        "payload" => {
+          "self" => "[recursive Hash]"
+        }
+      )
+    end
+
+    it "falls back when a param inspect raises SystemStackError" do
+      exploding_object = Class.new do
+        def inspect
+          raise SystemStackError, "stack level too deep"
+        end
+      end.new
+
+      allow(trace_double)
+        .to receive(:params)
+        .and_return({payload: exploding_object})
+
+      parsed_json = JSON.parse(described_class.json(trace_double))
+
+      expect(parsed_json.fetch("params")).to eq(
+        "payload" => "#<#{exploding_object.class} unserializable: SystemStackError: stack level too deep>"
+      )
+    end
   end
 end


### PR DESCRIPTION
Sanitize traced params before JSON encoding so recursive or problematic objects do not overflow the stack during logging. Add regression coverage for recursive payloads and SystemStackError fallbacks in the formatter.

Refs: https://github.com/carlosdanielpohlod/rails_tracepoint_stack/issues/37