### PR TITLE
Test newer Ruby releases in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: [3.0, 3.1, 3.2, 3.3, 3.4]
+        ruby-version: ['3.0', '3.1', '3.2', '3.3', '3.4', '3.5', '4.0']
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Extend the GitHub Actions matrix to cover Ruby 3.5 and 4.0 while keeping the existing stable MRI versions quoted for setup-ruby compatibility.