### PR TITLE
Trace blocks and scopes, and stop single values from swamping a trace

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rails_tracepoint_stack (0.4.0)
+    rails_tracepoint_stack (0.5.0)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -100,12 +100,42 @@ A real request produces tens of thousands of traces, so captures are bounded.
 | `max_traces` | 5000 | Stops collecting; `session.truncated?` becomes true |
 | `max_string_length` | 200 | Shortens long strings |
 | `max_collection_size` | 20 | Shortens long arrays and hashes |
+| `max_value_length` | 1000 | Replaces any single value larger than this with its size |
 | `capture_params` | `true` | Set false to show only the flow |
 | `capture_return` | `true` | Set false to show only the calls |
 | `threads` | `:current` | `:all` also records background threads |
+| `blocks` | `false` | `true` also traces blocks — see below |
 
 ```ruby
 RailsTracepointStack.capture(max_depth: 3, capture_return: false) { ... }
+```
+
+### Blocks and scopes
+
+A Rails scope is a lambda, so the logic inside it is not a method call and does
+not appear by default. `blocks: true` traces block entry and exit as well:
+
+```ruby
+RailsTracepointStack.capture(blocks: true) { News.latest(User.current) }
+```
+
+```
+News.latest (app/models/news.rb:88) {"user":"Anonymous"}
+  block { } (app/models/news.rb:46) {"user":"Anonymous"}
+    Project.allowed_to_condition (app/models/project.rb:189) {"permission":"view_news"}
+      ↻ 40× AccessControl.permission { } (lib/redmine/access_control.rb:37) {"p":"#<Permission …>"}
+        -> false
+```
+
+It is off by default because a block written inside a loop runs once per
+element: in Redmine, one call produced 48 block events and 43 of them came from
+a single `detect` predicate. Runs of the same block at the same depth collapse
+into one line with a `↻ N×` count, which keeps only the first run's arguments —
+if you need every iteration, leave blocks off and read the loop instead.
+
+Blocks are named after the method they were written in. A block with no
+enclosing method — a scope, a lambda held in a constant — has neither a class
+nor a method name to show, so it renders as `block { }` plus its location.
 ```
 
 ## Tracing the whole process

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## 0.5.0
+
+**Features**
+
+- `capture(blocks: true)` traces block entry and exit, which is what makes a
+  Rails scope, a lambda held in a constant, or any yielded block visible.
+  Off by default: a block inside a loop runs once per element. Runs of the
+  same block at the same depth collapse into one record with a `↻ N×` count
+- `max_value_length` (default 1000) caps any single value, whatever its shape
+
+**BugFix**
+
+- `to_tree` raised `Encoding::CompatibilityError` whenever a traced value held
+  bytes that are not text — a file read in binary mode, a digest, a response
+  body. Strings are now converted to UTF-8 with invalid bytes replaced
+- A class method on an ActiveRecord model rendered as its singleton class,
+  which prints the model's entire schema for a single call. The class name now
+  comes from the module's own name
+- Per-string and per-collection limits still let one value through at thousands
+  of characters, since twenty items truncated to two hundred each is four
+  thousand
+- The block handed to `capture` was traced as part of the result and consumed a
+  level of depth, indenting everything under it
+
 ## 0.4.0
 
 **Features**

--- a/lib/rails_tracepoint_stack.rb
+++ b/lib/rails_tracepoint_stack.rb
@@ -22,11 +22,16 @@ module RailsTracepointStack
   end
 
   CAPTURE_EVENTS = [:call, :return, :raise].freeze
+  BLOCK_EVENTS = [:b_call, :b_return].freeze
 
   # Traces a block and hands back everything that happened inside it, instead
   # of writing to a log. Meant to be run as a one-off: capture, read, done.
-  def self.capture(threads: :current, **limit_options)
-    raise ArgumentError, "Block not given to #capture" unless block_given?
+  # Blocks are off by default: a block written inside a loop fires once per
+  # element, so watching them costs more traces than watching methods does.
+  # Turn them on to see scopes, lambdas and anything else whose logic lives in
+  # a block rather than a method.
+  def self.capture(threads: :current, blocks: false, **limit_options, &traced)
+    raise ArgumentError, "Block not given to #capture" unless traced
 
     collector = RailsTracepointStack::Sink::Collector.new(
       limits: RailsTracepointStack::Limits.new(**limit_options)
@@ -34,13 +39,14 @@ module RailsTracepointStack
     session = collector.session
     tracer = RailsTracepointStack::Tracer.new(
       sink: collector,
-      events: CAPTURE_EVENTS,
-      thread: (threads == :all) ? nil : Thread.current
+      events: blocks ? CAPTURE_EVENTS + BLOCK_EVENTS : CAPTURE_EVENTS,
+      thread: (threads == :all) ? nil : Thread.current,
+      own_block: traced
     )
 
     tracer.enable
     begin
-      session.result = yield(session)
+      session.result = traced.call(session)
     rescue Exception => error
       session.error = error
       raise

--- a/lib/rails_tracepoint_stack/limits.rb
+++ b/lib/rails_tracepoint_stack/limits.rb
@@ -6,11 +6,13 @@ module RailsTracepointStack
     DEFAULT_MAX_TRACES = 5_000
     DEFAULT_MAX_STRING_LENGTH = 200
     DEFAULT_MAX_COLLECTION_SIZE = 20
+    DEFAULT_MAX_VALUE_LENGTH = 1_000
 
     attr_reader :max_depth,
       :max_traces,
       :max_string_length,
       :max_collection_size,
+      :max_value_length,
       :capture_params,
       :capture_return
 
@@ -19,6 +21,7 @@ module RailsTracepointStack
       max_traces: DEFAULT_MAX_TRACES,
       max_string_length: DEFAULT_MAX_STRING_LENGTH,
       max_collection_size: DEFAULT_MAX_COLLECTION_SIZE,
+      max_value_length: DEFAULT_MAX_VALUE_LENGTH,
       capture_params: true,
       capture_return: true
     )
@@ -26,6 +29,7 @@ module RailsTracepointStack
       @max_traces = max_traces
       @max_string_length = max_string_length
       @max_collection_size = max_collection_size
+      @max_value_length = max_value_length
       @capture_params = capture_params
       @capture_return = capture_return
     end

--- a/lib/rails_tracepoint_stack/log_formatter.rb
+++ b/lib/rails_tracepoint_stack/log_formatter.rb
@@ -25,12 +25,34 @@ module RailsTracepointStack
       )
     end
 
+    REPLACEMENT = "�".freeze
+
     def self.stringify(value)
       return nil if value.nil?
 
-      value.to_s
+      utf8(value.to_s)
     rescue SystemStackError, StandardError => error
       inspect_fallback(value, error)
+    end
+
+    # Traced code holds bytes that are not text: a file read in binary mode, a
+    # digest, a response body. Left as they are, those strings poison every
+    # consumer downstream - JSON refuses to encode them, and joining them with
+    # the rest of the output raises Encoding::CompatibilityError. Normalizing
+    # here keeps the damage to the one value that caused it.
+    def self.utf8(value)
+      return value unless value.is_a?(String)
+
+      converted =
+        if value.encoding == Encoding::UTF_8
+          value
+        else
+          value.encode(Encoding::UTF_8, invalid: :replace, undef: :replace, replace: REPLACEMENT)
+        end
+
+      converted.valid_encoding? ? converted : converted.scrub(REPLACEMENT)
+    rescue SystemStackError, StandardError
+      value.scrub(REPLACEMENT)
     end
 
     def self.safe_value(value, ancestry = {})
@@ -40,7 +62,7 @@ module RailsTracepointStack
       when String
         # Callers may keep the result around after the traced code moved on,
         # so a live reference to a mutable string would drift.
-        value.frozen? ? value : value.dup.freeze
+        utf8(value).dup.freeze
       when Symbol
         value.to_s
       when Array
@@ -125,7 +147,7 @@ module RailsTracepointStack
     end
 
     def self.safe_object_string(value)
-      value.inspect
+      utf8(value.inspect)
     rescue SystemStackError, StandardError => error
       inspect_fallback(value, error)
     end
@@ -146,7 +168,7 @@ module RailsTracepointStack
       when true, false, Numeric
         value.to_s
       when String
-        value.inspect
+        utf8(value).inspect
       when Symbol
         ":#{value}"
       when Array

--- a/lib/rails_tracepoint_stack/renderer/tree.rb
+++ b/lib/rails_tracepoint_stack/renderer/tree.rb
@@ -32,9 +32,32 @@ module RailsTracepointStack
       def self.line_for(record)
         case record.kind
         when :call then call_line(record)
-        when :return then return_line(record)
+        when :b_call then block_line(record)
+        when :return, :b_return then return_line(record)
         when :raise then raise_line(record)
         end
+      end
+
+      # A block has no name of its own. TracePoint reports the method it was
+      # written in, which is the useful label; a block written at class-body
+      # level - a scope, a lambda constant - has neither, so the location is
+      # all there is to show.
+      def self.block_line(record)
+        "#{indent(record.depth)}#{repeat_marker(record)}#{block_name(record)} { } " \
+          "(#{location(record)}) #{compact(record.params)}"
+      end
+
+      def self.block_name(record)
+        return "block" if record.class_name.nil? || record.method_name.nil?
+
+        qualified_name(record)
+      end
+
+      def self.repeat_marker(record)
+        count = record.repeats.to_i
+        return "" if count <= 1
+
+        "↻ #{count}× "
       end
 
       # Stops at the first character that cannot be part of a constant name, so

--- a/lib/rails_tracepoint_stack/renderer/tree.rb
+++ b/lib/rails_tracepoint_stack/renderer/tree.rb
@@ -37,7 +37,11 @@ module RailsTracepointStack
         end
       end
 
-      SINGLETON_CLASS = /\A#<Class:([A-Z][\w:]*)>\z/
+      # Stops at the first character that cannot be part of a constant name, so
+      # a singleton class that printed extra detail after its name still
+      # resolves. Requires a leading capital, which keeps anonymous singletons
+      # like #<Class:0x00007f1234> out.
+      SINGLETON_CLASS = /\A#<Class:([A-Z][\w:]*)[\s(>]/
       TEMPLATE_FILE = /\.(erb|haml|slim|builder|jbuilder|rabl)\z/i
       # Everything a template receives besides the locals belongs to the
       # rendering machinery, not to the developer.

--- a/lib/rails_tracepoint_stack/sink/collector.rb
+++ b/lib/rails_tracepoint_stack/sink/collector.rb
@@ -34,7 +34,7 @@ module RailsTracepointStack
 
         RailsTracepointStack::TraceRecord.new(
           kind: trace.kind,
-          class_name: RailsTracepointStack::LogFormatter.stringify(trace.class_name),
+          class_name: class_name_for(trace),
           method_name: trace.method_name,
           file_path: trace.file_path,
           line_number: trace.line_number,
@@ -44,6 +44,35 @@ module RailsTracepointStack
           exception_message: exception && RailsTracepointStack::LogFormatter.stringify(exception.message),
           depth: trace.depth || 0
         )
+      end
+
+      # `to_s` on a class is whatever that class decided to print. ActiveRecord
+      # makes a model's singleton class print its entire schema, which turns one
+      # method call into hundreds of characters of column definitions. A module
+      # knows its own name, so ask for that instead and only fall back to `to_s`
+      # for the anonymous ones that have none.
+      def class_name_for(trace)
+        klass = trace.class_name
+        return RailsTracepointStack::LogFormatter.stringify(klass) unless klass.is_a?(Module)
+
+        name = klass.name
+        return name if name
+
+        attached = attached_module(klass)
+        return "#<Class:#{attached.name}>" if attached&.name
+
+        RailsTracepointStack::LogFormatter.stringify(klass)
+      end
+
+      # Singleton classes have no name of their own. Ruby 3.2 can hand back the
+      # object they belong to; older versions leave only the printed form.
+      def attached_module(klass)
+        return nil unless klass.respond_to?(:attached_object)
+
+        attached = klass.attached_object
+        attached.is_a?(Module) ? attached : nil
+      rescue SystemStackError, StandardError
+        nil
       end
 
       def params_for(trace)
@@ -59,7 +88,7 @@ module RailsTracepointStack
       end
 
       def snapshot(value)
-        RailsTracepointStack::Truncator.call(
+        RailsTracepointStack::Truncator.bounded(
           RailsTracepointStack::LogFormatter.safe_value(value),
           limits
         )

--- a/lib/rails_tracepoint_stack/sink/collector.rb
+++ b/lib/rails_tracepoint_stack/sink/collector.rb
@@ -14,6 +14,8 @@ module RailsTracepointStack
       def initialize(session: RailsTracepointStack::TraceSession.new, limits: RailsTracepointStack::Limits.new)
         @session = session
         @limits = limits
+        @open_block = nil
+        @suppressed_returns = Hash.new(0)
       end
 
       def record(trace)
@@ -24,10 +26,47 @@ module RailsTracepointStack
           return
         end
 
-        session.add(build_record(trace))
+        built = build_record(trace)
+        return if collapsed?(built)
+
+        session.add(built)
       end
 
       private
+
+      # A block written inside a loop runs once per element and reports the
+      # same location every time, which buries the trace it belongs to. Runs of
+      # the same block at the same depth become one record carrying a count,
+      # and the matching returns are dropped with them.
+      def collapsed?(record)
+        return drop_suppressed_return(record) if record.block_return?
+        return break_run(record) unless record.block_call?
+
+        key = [record.file_path, record.line_number, record.depth]
+
+        if @open_block && @open_block.first == key
+          @open_block.last.repeats += 1
+          @suppressed_returns[record.depth] += 1
+          return true
+        end
+
+        @open_block = [key, record]
+        false
+      end
+
+      def drop_suppressed_return(record)
+        return false unless @suppressed_returns[record.depth] > 0
+
+        @suppressed_returns[record.depth] -= 1
+        true
+      end
+
+      # Anything that is not part of the block's own call/return pair ends the
+      # run, so two separate loops over the same line stay separate.
+      def break_run(record)
+        @open_block = nil unless record.returned?
+        false
+      end
 
       def build_record(trace)
         exception = trace.exception
@@ -42,7 +81,8 @@ module RailsTracepointStack
           return_value: return_value_for(trace),
           exception_class: exception && exception.class.to_s,
           exception_message: exception && RailsTracepointStack::LogFormatter.stringify(exception.message),
-          depth: trace.depth || 0
+          depth: trace.depth || 0,
+          repeats: 1
         )
       end
 

--- a/lib/rails_tracepoint_stack/templates/skill.md
+++ b/lib/rails_tracepoint_stack/templates/skill.md
@@ -75,9 +75,29 @@ unbounded capture of a real request is tens of thousands of lines.
 | `max_traces:` | 5000 | Cap total lines |
 | `max_string_length:` | 200 | Keep big payloads readable |
 | `max_collection_size:` | 20 | Keep loaded associations readable |
+| `max_value_length:` | 1000 | Cap any single value, whatever its shape |
 | `capture_params: false` | on | Show only the flow |
 | `capture_return: false` | on | Show only the calls |
 | `threads: :all` | current only | Include background threads |
+| `blocks: true` | off | Also trace blocks — see below |
+
+### When a scope or lambda seems to do nothing
+
+A Rails scope is a lambda, not a method, so by default nothing inside it shows
+up — you see the call that used the scope and then its result, with no steps in
+between. Same for any `yield`ed block. Add `blocks: true`:
+
+```ruby
+RailsTracepointStack.capture(blocks: true) { News.latest(User.current) }
+```
+
+Blocks render as `Class#method { }`, or as `block { }` plus a location when the
+block has no enclosing method (which is what a scope looks like). A line like
+`↻ 40× ... { }` means that block ran 40 times from the same place — a predicate
+inside a loop — and only the first run's arguments were kept.
+
+Leave it off unless you need it. A block inside a loop fires once per element,
+so this costs far more traces than watching methods does.
 
 To narrow by file instead, set patterns before capturing:
 

--- a/lib/rails_tracepoint_stack/trace.rb
+++ b/lib/rails_tracepoint_stack/trace.rb
@@ -20,14 +20,17 @@ module RailsTracepointStack
       trace_point.event
     end
 
+    ENTERING = [:call, :b_call].freeze
+    LEAVING = [:return, :b_return].freeze
+
     def params
-      return {} unless kind == :call
+      return {} unless ENTERING.include?(kind)
 
       @params ||= fetch_params(trace_point)
     end
 
     def return_value
-      return nil unless kind == :return
+      return nil unless LEAVING.include?(kind)
 
       trace_point.return_value
     end

--- a/lib/rails_tracepoint_stack/trace_record.rb
+++ b/lib/rails_tracepoint_stack/trace_record.rb
@@ -13,6 +13,7 @@ module RailsTracepointStack
     :exception_class,
     :exception_message,
     :depth,
+    :repeats,
     keyword_init: true
   ) do
     def call?
@@ -25,6 +26,20 @@ module RailsTracepointStack
 
     def raise?
       kind == :raise
+    end
+
+    def block_call?
+      kind == :b_call
+    end
+
+    def block_return?
+      kind == :b_return
+    end
+
+    # True for anything that produced a value on the way out, so callers do not
+    # have to know whether a method or a block produced it.
+    def returned?
+      return? || block_return?
     end
   end
 end

--- a/lib/rails_tracepoint_stack/tracer.rb
+++ b/lib/rails_tracepoint_stack/tracer.rb
@@ -23,10 +23,20 @@ module RailsTracepointStack
     # A nil thread watches every thread in the process, which is what the
     # global tracer wants. Passing one confines tracing to it, so a capture
     # running inside a threaded server does not pick up other requests.
-    def initialize(sink: RailsTracepointStack::Sink::Log.new, events: DEFAULT_EVENTS, thread: nil)
+    # own_block is the block the caller wrapped around the code under
+    # inspection. It is the caller's own code, so it is skipped before a depth
+    # is assigned - otherwise it would indent the whole trace by a level it
+    # never shows.
+    def initialize(
+      sink: RailsTracepointStack::Sink::Log.new,
+      events: DEFAULT_EVENTS,
+      thread: nil,
+      own_block: nil
+    )
       @sink = sink
       @events = events
       @thread = thread
+      @own_block_location = own_block&.source_location
       @filtered_count = 0
       generate_tracer
     end
@@ -39,6 +49,8 @@ module RailsTracepointStack
 
         trace = RailsTracepointStack::Trace.new(trace_point: tracepoint)
 
+        next if own_block?(trace)
+
         if ignore_trace?(trace: trace)
           @filtered_count += 1
           next
@@ -47,6 +59,35 @@ module RailsTracepointStack
         trace.depth = depth_for(trace)
         @sink.record(trace)
       end
+    end
+
+    # Matching on location alone would also drop a block written on the same
+    # line as the capture call. The caller's block is the first to arrive from
+    # that location, so only that one is skipped, along with its return.
+    def own_block?(trace)
+      return false if @own_block_location.nil?
+
+      case trace.kind
+      when :b_call then claim_own_block(trace)
+      when :b_return then release_own_block(trace)
+      else false
+      end
+    end
+
+    def claim_own_block(trace)
+      return false if @own_block_seen
+      return false unless [trace.file_path, trace.line_number] == @own_block_location
+
+      @own_block_seen = true
+      @own_block_position = raw_stack_position
+      true
+    end
+
+    def release_own_block(trace)
+      return false unless @own_block_position && raw_stack_position == @own_block_position
+
+      @own_block_position = nil
+      true
     end
 
     def out_of_scope_thread?
@@ -61,8 +102,8 @@ module RailsTracepointStack
       raw_position = raw_stack_position
 
       case trace.kind
-      when :call then tracker.enter(raw_position)
-      when :return then tracker.leave(raw_position)
+      when :call, :b_call then tracker.enter(raw_position)
+      when :return, :b_return then tracker.leave(raw_position)
       when :raise then tracker.raised(raw_position)
       end
     end

--- a/lib/rails_tracepoint_stack/tracer.rb
+++ b/lib/rails_tracepoint_stack/tracer.rb
@@ -36,7 +36,9 @@ module RailsTracepointStack
       @sink = sink
       @events = events
       @thread = thread
-      @own_block_location = own_block&.source_location
+      # Ruby has grown extra entries on source_location over time (columns, end
+      # positions), so only the file and the line are compared.
+      @own_block_location = own_block&.source_location&.first(2)
       @filtered_count = 0
       generate_tracer
     end

--- a/lib/rails_tracepoint_stack/truncator.rb
+++ b/lib/rails_tracepoint_stack/truncator.rb
@@ -1,3 +1,5 @@
+require "json"
+
 module RailsTracepointStack
   # Shrinks an already-serialized value so one fat argument (a big payload, a
   # long SQL string, a loaded association) cannot dominate the output. Runs
@@ -5,6 +7,39 @@ module RailsTracepointStack
   # ever sees strings, numbers, booleans, nil, arrays and hashes.
   module Truncator
     ELLIPSIS = "…".freeze
+
+    # Per-string and per-collection limits still leave room for one value to
+    # run to thousands of characters: twenty items each truncated to two
+    # hundred is still four thousand. This caps the value as a whole, and does
+    # it before the per-item truncation so the summary can report the real
+    # size rather than the already-shrunk one.
+    def self.bounded(value, limits)
+      capped = cap(value, limits)
+      return capped unless capped.equal?(value)
+
+      call(value, limits)
+    end
+
+    def self.cap(value, limits)
+      max = limits.max_value_length
+      return value if max.nil?
+      return value unless value.is_a?(String) || value.is_a?(Array) || value.is_a?(Hash)
+
+      size = JSON.generate(value).length
+      return value if size <= max
+
+      summarize(value, size)
+    rescue SystemStackError, StandardError
+      value
+    end
+
+    def self.summarize(value, size)
+      case value
+      when Array then "[#{value.size} items, #{size} chars — over max_value_length]"
+      when Hash then "{#{value.size} keys, #{size} chars — over max_value_length}"
+      else "[#{size} chars — over max_value_length]"
+      end
+    end
 
     def self.call(value, limits)
       case value

--- a/lib/rails_tracepoint_stack/version.rb
+++ b/lib/rails_tracepoint_stack/version.rb
@@ -1,3 +1,3 @@
 module RailsTracepointStack
-  VERSION = "0.4.0"
+  VERSION = "0.5.0"
 end

--- a/spec/rails_tracepoint_stack/binary_values_spec.rb
+++ b/spec/rails_tracepoint_stack/binary_values_spec.rb
@@ -1,0 +1,60 @@
+require "spec_helper"
+
+RSpec.describe "values that are not UTF-8" do
+  before do
+    RailsTracepointStack.configure do |config|
+      config.file_path_to_filter_patterns = [%r{spec/support/trace_subject}]
+    end
+  end
+
+  # A JPEG header: bytes that are valid nowhere in UTF-8. Anything reading a
+  # file in binary mode, hashing, or holding a response body produces these.
+  let(:binary) { "\xFF\xD8\xFF\xE0JFIF".dup.force_encoding(Encoding::BINARY) }
+  # Bytes that happen to be ASCII, so only the encoding tag is wrong.
+  let(:ascii_tagged_binary) { "plain bytes".dup.force_encoding(Encoding::BINARY) }
+  # Tagged UTF-8, but holding a byte sequence that is not valid UTF-8.
+  let(:broken_utf8) { "caf\xC3".dup.force_encoding(Encoding::UTF_8) }
+
+  def capture_echo(value)
+    RailsTracepointStack.capture { TraceSubject.new.echo(value) }
+  end
+
+  describe "#to_tree" do
+    it "renders a binary argument instead of raising" do
+      expect { capture_echo(binary).to_tree }.not_to raise_error
+    end
+
+    it "renders binary bytes that happen to be ASCII" do
+      expect(capture_echo(ascii_tagged_binary).to_tree).to include("plain bytes")
+    end
+
+    it "renders a string tagged UTF-8 that holds invalid bytes" do
+      expect { capture_echo(broken_utf8).to_tree }.not_to raise_error
+    end
+
+    it "produces a tree that is valid UTF-8" do
+      tree = capture_echo(binary).to_tree
+
+      expect(tree.encoding).to eq(Encoding::UTF_8)
+      expect(tree).to be_valid_encoding
+    end
+  end
+
+  describe "#to_json" do
+    it "serializes a binary argument instead of raising" do
+      expect { capture_echo(binary).to_json }.not_to raise_error
+    end
+  end
+
+  describe "the text log format" do
+    it "formats a binary argument instead of raising" do
+      expect { RailsTracepointStack::LogFormatter.text_value(binary) }.not_to raise_error
+    end
+  end
+
+  it "leaves a normal UTF-8 string untouched" do
+    tree = capture_echo("olá, mundo — çãé").to_tree
+
+    expect(tree).to include("olá, mundo — çãé")
+  end
+end

--- a/spec/rails_tracepoint_stack/blocks_spec.rb
+++ b/spec/rails_tracepoint_stack/blocks_spec.rb
@@ -1,0 +1,127 @@
+require "spec_helper"
+
+RSpec.describe "tracing blocks" do
+  before do
+    RailsTracepointStack.configure do |config|
+      config.file_path_to_filter_patterns = [%r{spec/support/trace_subject}]
+    end
+  end
+
+  def block_records(session)
+    session.traces.select(&:block_call?)
+  end
+
+  describe "by default" do
+    it "does not trace blocks" do
+      session = RailsTracepointStack.capture { TraceSubject.new.calls_a_block }
+
+      expect(block_records(session)).to be_empty
+    end
+  end
+
+  describe "with blocks: true" do
+    it "records the block" do
+      session = RailsTracepointStack.capture(blocks: true) { TraceSubject.new.calls_a_block }
+
+      expect(block_records(session)).not_to be_empty
+    end
+
+    it "keeps the arguments the block received" do
+      session = RailsTracepointStack.capture(blocks: true) { TraceSubject.new.calls_a_block }
+
+      expect(block_records(session).map(&:params)).to include({"value" => 7})
+    end
+
+    it "keeps what the block returned" do
+      session = RailsTracepointStack.capture(blocks: true) { TraceSubject.new.calls_a_block }
+      returned = session.traces.select(&:block_return?).map(&:return_value)
+
+      expect(returned).to include(8)
+    end
+
+    it "nests the block under the method that called it" do
+      session = RailsTracepointStack.capture(blocks: true) { TraceSubject.new.calls_a_block }
+      outer = session.traces.find { |t| t.call? && t.method_name == :calls_a_block }
+
+      expect(block_records(session).map(&:depth).min).to be > outer.depth
+    end
+  end
+
+  describe "a block that runs once per element" do
+    subject(:session) do
+      RailsTracepointStack.capture(blocks: true) { TraceSubject.new.repeated_block }
+    end
+
+    it "collapses the repeats into a single record" do
+      expect(block_records(session).size).to eq(1)
+    end
+
+    it "counts how many times it ran" do
+      expect(block_records(session).first.repeats).to eq(5)
+    end
+
+    it "shows the count in the tree" do
+      expect(session.to_tree).to match(/5× /)
+    end
+
+    it "does not leave the returns behind" do
+      expect(session.traces.select(&:block_return?).size).to eq(1)
+    end
+  end
+
+  describe "the block handed to capture" do
+    before do
+      RailsTracepointStack.configure do |config|
+        config.file_path_to_filter_patterns = [%r{spec/rails_tracepoint_stack/blocks_spec}]
+      end
+    end
+
+    it "is not part of the trace" do
+      session = RailsTracepointStack.capture(blocks: true) { 1 + 1 }
+
+      expect(session.traces).to be_empty
+    end
+
+    # The capture block only reaches this code when it lives in a traced file,
+    # so both paths have to be watched for the phantom level to show up.
+    it "does not take a level of depth with it" do
+      RailsTracepointStack.configure do |config|
+        config.file_path_to_filter_patterns = [
+          %r{spec/support/trace_subject},
+          %r{spec/rails_tracepoint_stack/blocks_spec}
+        ]
+      end
+
+      session = RailsTracepointStack.capture(blocks: true) { TraceSubject.new.add(1, 2) }
+
+      expect(session.traces.map(&:depth).min).to eq(0)
+    end
+
+    it "does not hide blocks written on the same line" do
+      session = RailsTracepointStack.capture(blocks: true) { [1].each { |n| } }
+
+      expect(session.traces.select(&:block_call?).size).to eq(1)
+    end
+  end
+
+  describe "naming" do
+    it "names a block by the method it was written in" do
+      session = RailsTracepointStack.capture(blocks: true) { TraceSubject.new.calls_a_block }
+
+      expect(session.to_tree).to include("TraceSubject#calls_a_block { }")
+    end
+
+    it "falls back to the location for a block with no enclosing method" do
+      session = RailsTracepointStack.capture(blocks: true) { TraceSubject.new.runs_scope_like(2) }
+      line = session.to_tree.lines.find { |l| l.include?("block") }
+
+      expect(line).to match(%r{block \{ \} \(spec/support/trace_subject\.rb:\d+\)})
+    end
+
+    it "still records what that block returned" do
+      session = RailsTracepointStack.capture(blocks: true) { TraceSubject.new.runs_scope_like(2) }
+
+      expect(session.traces.select(&:block_return?).map(&:return_value)).to include(6)
+    end
+  end
+end

--- a/spec/rails_tracepoint_stack/noisy_values_spec.rb
+++ b/spec/rails_tracepoint_stack/noisy_values_spec.rb
@@ -1,0 +1,57 @@
+require "spec_helper"
+require "json"
+
+RSpec.describe "values that would swamp the output" do
+  before do
+    RailsTracepointStack.configure do |config|
+      config.file_path_to_filter_patterns = [%r{spec/support/trace_subject}]
+    end
+  end
+
+  describe "a class whose singleton class prints more than its name" do
+    subject(:tree) do
+      RailsTracepointStack.capture { NoisySingletonSubject.build(2) }.to_tree
+    end
+
+    it "renders the call as plain dot notation" do
+      expect(tree).to start_with("NoisySingletonSubject.build ")
+    end
+
+    it "leaves the noise out of the line" do
+      expect(tree).not_to include("load_schema")
+    end
+  end
+
+  describe "a return value too large to be worth printing" do
+    subject(:session) do
+      RailsTracepointStack.capture(max_value_length: 300) do
+        NoisySingletonSubject.many_objects
+      end
+    end
+
+    let(:returned) do
+      session.traces.find { |record| record.return? && record.method_name == :many_objects }
+    end
+
+    it "replaces the value with something that fits the limit" do
+      expect(JSON.generate(returned.return_value).length).to be <= 300
+    end
+
+    it "says how many items were dropped" do
+      expect(returned.return_value.to_s).to include("80 items")
+    end
+
+    it "says which limit cut it" do
+      expect(returned.return_value.to_s).to include("max_value_length")
+    end
+
+    it "keeps a small value untouched" do
+      small = RailsTracepointStack.capture(max_value_length: 300) do
+        TraceSubject.new.add(1, 2)
+      end
+      record = small.traces.find { |trace| trace.return? && trace.method_name == :add }
+
+      expect(record.return_value).to eq(3)
+    end
+  end
+end

--- a/spec/support/trace_subject.rb
+++ b/spec/support/trace_subject.rb
@@ -1,8 +1,30 @@
 # Real classes exercised by the tracer specs. Traces are matched by
 # `defined_class`, so these must live outside the spec files that use them.
 class TraceSubject
+  # A Rails scope is a lambda held at class-body level: TracePoint reports it
+  # with no defining class and no method name.
+  SCOPE_LIKE = lambda { |factor| factor * 3 }
+
   def self.build(value)
     new
+  end
+
+  # The block runs once per element, all from the same line — the shape that
+  # floods a trace.
+  def repeated_block
+    [1, 2, 3, 4, 5].map { |number| number * 2 }
+  end
+
+  def runs_scope_like(factor)
+    SCOPE_LIKE.call(factor)
+  end
+
+  def yields_once
+    yield 7
+  end
+
+  def calls_a_block
+    yields_once { |value| value + 1 }
   end
 
   def add(first, second)

--- a/spec/support/trace_subject.rb
+++ b/spec/support/trace_subject.rb
@@ -62,6 +62,23 @@ class TraceSubject
   end
 end
 
+# ActiveRecord makes a model's singleton class print its whole schema, and
+# leaves its `name` nil. This reproduces that shape without pulling in Rails.
+class NoisySingletonSubject
+  def self.build(value)
+    value * 2
+  end
+
+  def self.many_objects
+    Array.new(80) { |index| Struct.new(:a, :b, :c).new("x" * 120, index, "y" * 120) }
+  end
+end
+
+NoisySingletonSubject.singleton_class.define_singleton_method(:to_s) do
+  "#<Class:NoisySingletonSubject (call 'NoisySingletonSubject.load_schema' " \
+    "to load schema information)>"
+end
+
 TraceEntry = Struct.new(:kind, :params, :return_value, :exception, :method_name, :depth)
 
 # Collects whatever the tracer hands it, so specs can assert on real traces


### PR DESCRIPTION
Three defects the 0.4.0 release shipped with, plus the feature that made them
visible. All four were found by benchmarking the gem against
[Redmine](https://github.com/redmine/redmine) — a real Rails app, 37k lines
under `app/` — rather than against the toy app I had been testing on.

## Blocks and scopes were invisible

A Rails scope is a lambda, not a method, so nothing inside it was traced. You
saw the call that used the scope and then its result, with no steps between —
and scopes are where a lot of Rails query logic lives.

`capture(blocks: true)` now watches block entry and exit:

```
News.latest (app/models/news.rb:88) {"user":"Anonymous"}
  block { } (app/models/news.rb:46) {"user":"Anonymous"}          <- the scope
    Project.allowed_to_condition (app/models/project.rb:189) {"permission":"view_news"}
      ↻ 40× AccessControl.permission { } (lib/redmine/access_control.rb:37) {"p":"#<Permission …>"}
        -> false
```

**Off by default, and the measurement is why.** Tracing `News.latest` in Redmine
produced 23 method events and **48 block events — 43 of them from a single
`detect` predicate**. Turning blocks on unconditionally would have taken that
trace from 23 lines to 71, 43 of them identical.

So runs of the same block at the same depth collapse into one record carrying a
count. That is lossy: only the first run's arguments are kept. For a `detect`
predicate that is the right trade; if you need every iteration, leave blocks off.

Blocks are named after the method they were written in. A scope has neither a
defining class nor a method name — TracePoint reports `nil` for both — so it
renders as `block { }` plus its location.

## `to_tree` crashed on binary data

Any traced value holding bytes that are not text — a file read in binary mode, a
digest, a response body — raised `Encoding::CompatibilityError` from `Array#join`
when the tree was rendered. A real Rails request carries these, so this is
reachable on the released version. Strings are now converted to UTF-8 with
invalid bytes replaced at the point they enter the formatter, which covers the
tree, `as_json` and the text log at once.

## One class name or one value could swamp a trace

A class method on an ActiveRecord model rendered as its singleton class, and
`ActiveRecord` makes that print the model's entire schema:

```
#<Class:User(id: integer, login: string, hashed_password: string, … 21 columns)>#anonymous
```

The class name now comes from `Module#name`, resolving singletons through
`attached_object` where available and falling back to the printed form on older
Rubies.

Separately, the per-string and per-collection limits still allowed a single
value through at thousands of characters — twenty items truncated to two hundred
each is four thousand. `max_value_length` (default 1000) caps the value as a
whole and reports the size it replaced.

Together these took the scoped Redmine capture from **2,643 to 873 tokens** for
the same 47 lines. The whole difference was noise per line.

## The block handed to `capture` was in its own trace

It sat at the root of every `blocks: true` capture and consumed a level of
depth, indenting everything under it by a level that was never shown. It is
skipped in the tracer, before a depth is assigned, matched by the block's
`source_location` — and only the first block from that location, so a block
written on the same line as the `capture` call is not swallowed with it.

## Verification

157 examples, 0 failures (was 142). Each fix has tests that failed first.
`gem build` produces 0.5.0.

The version is 0.5.0 rather than 0.4.1 because of the `blocks:` feature — say
the word if you'd rather split the fixes into a 0.4.1 and hold the feature.

## Not fixed

**Repeated method calls do not collapse.** A loop calling the same app method
floods the trace the same way blocks did. I left it alone because the trade is
different: for a block predicate, losing each iteration's arguments is fine; for
a method, the return value of *each* call is exactly what this gem exists to
show, and collapsing could hide the one call that returned `nil`. That needs a
better rule than "same location".
